### PR TITLE
Add completion mode and stats for more prediction insight

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -6,19 +6,19 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5">
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
 		<attributes>
+			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+		<attributes>
+			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
 		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
-		<attributes>
-			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>

--- a/src/main/java/slp/core/modeling/runners/Completion.java
+++ b/src/main/java/slp/core/modeling/runners/Completion.java
@@ -1,0 +1,40 @@
+package slp.core.modeling.runners;
+
+import java.util.List;
+
+import slp.core.util.Pair;
+
+public class Completion {
+	private final Integer realIx;
+	private final List<Pair<Integer, Double>> completions;
+	
+	public Completion(Integer realIx, List<Pair<Integer, Double>> predictions) {
+		this.realIx = realIx;
+		this.completions = predictions;
+	}
+
+	public Completion(List<Pair<Integer, Double>> predictions) {
+		this.realIx = null;
+		this.completions = predictions;
+	}
+
+	public List<Pair<Integer, Double>> getPredictions() {
+		return completions;
+	}
+
+	public Integer getRealIx() {
+		return realIx;
+	}
+	
+	public int getRank() {
+		if (this.realIx == null) return -1;
+		else {
+			for (int i = 0; i < this.completions.size(); i++) {
+				if (this.completions.get(i).left.equals(this.realIx)) {
+					return i;
+				}
+			}
+			return -1;
+		}
+	}
+}


### PR DESCRIPTION
The `predict` modes of `ModelRunner` only return an MRR summary of prediction accuracy, which is not helpful if you want to get actual predictions; it was just designed to collect statistics. With this update,  the `ModelRunner` gets a suite of `complete...` methods that match the `predict` methods, but return `Completion` objects instead, which contain an ordered list of the top-k recommendations with their probabilities.
`Completion`s contain an optional field that stores the true completion, which the `ModelRunner` sets correctly (so that it can compute ranks for you), but can be left empty in cases where this true completion is not known. This should not matter in most cases.