### PR TITLE
Correctly copy NGramModel parameters in Cache and NestedModel

### DIFF
--- a/src/main/java/slp/core/modeling/dynamic/CacheModel.java
+++ b/src/main/java/slp/core/modeling/dynamic/CacheModel.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import slp.core.counting.Counter;
 import slp.core.modeling.AbstractModel;
 import slp.core.modeling.Model;
 import slp.core.modeling.ngram.NGramModel;
@@ -48,7 +49,16 @@ public class CacheModel extends AbstractModel {
 	@Override
 	public void notify(File next) {
 		try {
-			this.model = this.model.getClass().getConstructor().newInstance();
+			if (this.model instanceof NGramModel) {
+				NGramModel asNgramModel = (NGramModel) this.model;
+				int order = asNgramModel.getOrder();
+				Counter counter = asNgramModel.getCounter();
+				this.model = this.model.getClass()
+						.getDeclaredConstructor(int.class, Counter.class)
+						.newInstance(order, counter);
+			} else {
+				this.model = this.model.getClass().getDeclaredConstructor().newInstance();
+			}
 		} catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException
 				| NoSuchMethodException | SecurityException e) {
 			this.model = NGramModel.standard();

--- a/src/main/java/slp/core/modeling/dynamic/NestedModel.java
+++ b/src/main/java/slp/core/modeling/dynamic/NestedModel.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import slp.core.counting.Counter;
 import slp.core.lexing.runners.LexerRunner;
 import slp.core.modeling.AbstractModel;
 import slp.core.modeling.Model;
@@ -70,7 +71,16 @@ public class NestedModel extends AbstractModel {
 
 	private Model newModel() {
 		try {
-			return this.global.getClass().getDeclaredConstructor().newInstance();
+			if (this.global instanceof NGramModel) {
+				NGramModel asNgramModel = (NGramModel) this.global;
+				int order = asNgramModel.getOrder();
+				Counter counter = asNgramModel.getCounter();
+				return this.global.getClass()
+						.getDeclaredConstructor(int.class, Counter.class)
+						.newInstance(order, counter);
+			} else {
+				return this.global.getClass().getDeclaredConstructor().newInstance();
+			}
 		} catch (InstantiationException | IllegalAccessException | IllegalArgumentException
 				| SecurityException | InvocationTargetException | NoSuchMethodException e) {
 			e.printStackTrace();

--- a/src/main/java/slp/core/modeling/ngram/NGramModel.java
+++ b/src/main/java/slp/core/modeling/ngram/NGramModel.java
@@ -41,6 +41,10 @@ public abstract class NGramModel extends AbstractModel {
 		return this.counter;
 	}
 
+	public int getOrder() {
+		return this.order;
+	}
+
 	@Override
 	public void notify(File next) { }
 


### PR DESCRIPTION
This change ensures that NGramModel's do not get copied without their intended parameters (through simple reflection) when the cache model and nested model require a new (empty) model. In due course, this should be made more general, either through a Model.copy() interface method or at least by moving this to an NGramModel static method. Any opinions on this are welcome.